### PR TITLE
Update from rpp to count to control the number of results

### DIFF
--- a/Oauth.php
+++ b/Oauth.php
@@ -100,14 +100,14 @@ function invalidate_bearer_token($bearer_token){
 /**
 * Search
 * Basic Search of the Search API
-* Based on https://dev.twitter.com/docs/api/1/get/search
+* Based on https://dev.twitter.com/docs/api/1.1/get/search/tweets
 */
-function search_for_a_term($bearer_token, $query, $result_type='mixed', $rpp='15'){
+function search_for_a_term($bearer_token, $query, $result_type='mixed', $count='15'){
 	$url = "https://api.twitter.com/1.1/search/tweets.json"; // base url
 	$q = urlencode(trim($query)); // query term
 	$formed_url ='?q='.$q; // fully formed url
 	if($result_type!='mixed'){$formed_url = $formed_url.'&result_type='.$result_type;} // result type - mixed(default), recent, popular
-	if($rpp!='15'){$formed_url = $formed_url.'&rpp='.$rpp;} // results per page - defaulted to 15
+	if($count!='15'){$formed_url = $formed_url.'&count='.$count;} // results per page - defaulted to 15
 	$formed_url = $formed_url.'&include_entities=true'; // makes sure the entities are included, note @mentions are not included see documentation
 	$headers = array( 
 		"GET /1.1/search/tweets.json".$formed_url." HTTP/1.1", 


### PR DESCRIPTION
The original is using the depreciated `rpp` parameter, which was making the results always kick back at ~50.  This simple change, in accordance with v1.1 of the Twitter API, updates the parameter to `count` so that you can actually control the number of results.

Supporting documentation on `count`:
https://dev.twitter.com/docs/api/1.1/get/search/tweets#api-param-search_count

Old documentation on `rpp`:
https://dev.twitter.com/docs/api/1/get/search#api-param-search_rpp
